### PR TITLE
Adding MuFilter segmentation and staggering

### DIFF
--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -76,6 +76,10 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DownstreamBarY = (c.MuFilter.DownstreamDetY + c.MuFilter.OverlapDownstreamBars * (c.MuFilter.NDownstreamBars - 1))/c.MuFilter.NDownstreamBars #computed for staggering
         c.MuFilter.DownstreamBarZ = 1*u.cm
 
+        c.MuFilter.DownstreamBarX_ver = (c.MuFilter.DownstreamDetX + c.MuFilter.OverlapDownstreamBars * (c.MuFilter.NDownstreamBars - 1))/c.MuFilter.NDownstreamBars
+        c.MuFilter.DownstreamBarY_ver = c.MuFilter.DownstreamDetY
+        c.MuFilter.DownstreamBarZ_ver = 1*u.cm
+
         #total z thickness and position
 	c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
 	c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -84,4 +84,4 @@ with ConfigRegistry.register_config("basic") as c:
 	c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
 	c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
 	c.MuFilter.ShiftX = c.EmulsionDet.ShiftX+c.EmulsionDet.xdim/2
-	c.MuFilter.ShiftY = 5.6*u.cm #overlap with floor of 2.3 cm with previous value of 3.3, need to compue floor height in future
+	c.MuFilter.ShiftY = 3.55*u.cm #since y size increased of 0.5, we need to increase this shift from 3.3 to 3.55

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -48,10 +48,10 @@ with ConfigRegistry.register_config("basic") as c:
 	#c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
 	c.MuFilter.X = 62.0*u.cm
         #c.MuFilter.Y = c.EmulsionDet.ydim + 20*u.cm+10.0*u.cm
-        c.MuFilter.Y = 60.0*u.cm+c.MuFilter.ShiftDYTot
+        c.MuFilter.Y = 60.5*u.cm+c.MuFilter.ShiftDYTot
         c.MuFilter.FeX = c.MuFilter.X
         #c.MuFilter.FeY = c.EmulsionDet.ydim + 20*u.cm
-        c.MuFilter.FeY = 60.5*u.cm
+        c.MuFilter.FeY = c.MuFilter.Y - c.MuFilter.ShiftDYTot
         c.MuFilter.FeZ = 20*u.cm
         c.MuFilter.UpstreamDetX = c.MuFilter.X
         c.MuFilter.UpstreamDetY = c.MuFilter.FeY
@@ -84,4 +84,4 @@ with ConfigRegistry.register_config("basic") as c:
 	c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
 	c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
 	c.MuFilter.ShiftX = c.EmulsionDet.ShiftX+c.EmulsionDet.xdim/2
-	c.MuFilter.ShiftY = 3.3*u.cm
+	c.MuFilter.ShiftY = 5.6*u.cm #overlap with floor of 2.3 cm with previous value of 3.3, need to compue floor height in future

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -46,7 +46,7 @@ with ConfigRegistry.register_config("basic") as c:
 	c.MuFilter.ShiftDY = 2.0*u.cm
 	c.MuFilter.ShiftDYTot = 6.0*u.cm
 	#c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
-	c.MuFilter.X = 61.6*u.cm
+	c.MuFilter.X = 62.0*u.cm
         #c.MuFilter.Y = c.EmulsionDet.ydim + 20*u.cm+10.0*u.cm
         c.MuFilter.Y = 60.0*u.cm+c.MuFilter.ShiftDYTot
         c.MuFilter.FeX = c.MuFilter.X

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -51,13 +51,33 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.Y = 60.0*u.cm+c.MuFilter.ShiftDYTot
         c.MuFilter.FeX = c.MuFilter.X
         #c.MuFilter.FeY = c.EmulsionDet.ydim + 20*u.cm
-        c.MuFilter.FeY = 60.0*u.cm
+        c.MuFilter.FeY = 60.5*u.cm
         c.MuFilter.FeZ = 20*u.cm
-        c.MuFilter.TDetX = c.MuFilter.X
-        c.MuFilter.TDetY = c.MuFilter.FeY
-        c.MuFilter.TDetZ = 2*u.cm
-        c.MuFilter.nplanes = 8
-	c.MuFilter.Z = c.MuFilter.nplanes*(c.MuFilter.FeZ+c.MuFilter.TDetZ)
+        c.MuFilter.UpstreamDetX = c.MuFilter.X
+        c.MuFilter.UpstreamDetY = c.MuFilter.FeY
+        c.MuFilter.UpstreamDetZ = 2*u.cm
+        c.MuFilter.NUpstreamPlanes = 5
+        c.MuFilter.DownstreamDetX = c.MuFilter.X
+        c.MuFilter.DownstreamDetY = c.MuFilter.FeY
+        c.MuFilter.DownstreamDetZ = 4*u.cm
+        c.MuFilter.NDownstreamPlanes=3
+        
+        #upstream bars configuration
+        c.MuFilter.NUpstreamBars = 11
+        c.MuFilter.OverlapUpstreamBars = 0.5*u.cm
+        c.MuFilter.UpstreamBarX = c.MuFilter.UpstreamDetX
+        c.MuFilter.UpstreamBarY = (c.MuFilter.UpstreamDetY + c.MuFilter.OverlapUpstreamBars * (c.MuFilter.NUpstreamBars - 1))/c.MuFilter.NUpstreamBars #computed for staggering
+        c.MuFilter.UpstreamBarZ = 1*u.cm
+
+        #downstream bars configuration
+        c.MuFilter.NDownstreamBars = 77 #n.d.r. both for x and y in this case
+        c.MuFilter.OverlapDownstreamBars = 0.2*u.cm
+        c.MuFilter.DownstreamBarX = c.MuFilter.DownstreamDetX
+        c.MuFilter.DownstreamBarY = (c.MuFilter.DownstreamDetY + c.MuFilter.OverlapDownstreamBars * (c.MuFilter.NDownstreamBars - 1))/c.MuFilter.NDownstreamBars #computed for staggering
+        c.MuFilter.DownstreamBarZ = 1*u.cm
+
+        #total z thickness and position
+	c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
 	c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
 	c.MuFilter.ShiftX = c.EmulsionDet.ShiftX+c.EmulsionDet.xdim/2
 	c.MuFilter.ShiftY = 3.3*u.cm

--- a/python/shipLHC_conf.py
+++ b/python/shipLHC_conf.py
@@ -56,8 +56,19 @@ def configure(run,ship_geo,Gfield=''):
  MuFilter = ROOT.MuFilter("MuFilter",ROOT.kTRUE)
  MuFilter.SetMuFilterDimensions(ship_geo.MuFilter.X, ship_geo.MuFilter.Y, ship_geo.MuFilter.Z)
  MuFilter.SetIronBlockDimensions(ship_geo.MuFilter.FeX, ship_geo.MuFilter.FeY, ship_geo.MuFilter.FeZ)
- MuFilter.SetTimingPlanesDimensions(ship_geo.MuFilter.TDetX, ship_geo.MuFilter.TDetY, ship_geo.MuFilter.TDetZ)
- MuFilter.SetNplanes(ship_geo.MuFilter.nplanes)
+ #upstream section
+ MuFilter.SetUpstreamPlanesDimensions(ship_geo.MuFilter.UpstreamDetX, ship_geo.MuFilter.UpstreamDetY, ship_geo.MuFilter.UpstreamDetZ)
+ MuFilter.SetNUpstreamPlanes(ship_geo.MuFilter.NUpstreamPlanes)
+ MuFilter.SetUpstreamBarsDimensions(ship_geo.MuFilter.UpstreamBarX, ship_geo.MuFilter.UpstreamBarY, ship_geo.MuFilter.UpstreamBarZ)
+ MuFilter.SetOverlapUpstreamBars(ship_geo.MuFilter.OverlapUpstreamBars)
+ MuFilter.SetNUpstreamBars(ship_geo.MuFilter.NUpstreamBars)
+ #downstream section
+ MuFilter.SetDownstreamPlanesDimensions(ship_geo.MuFilter.DownstreamDetX, ship_geo.MuFilter.DownstreamDetY, ship_geo.MuFilter.DownstreamDetZ)
+ MuFilter.SetNDownstreamPlanes(ship_geo.MuFilter.NDownstreamPlanes)
+ MuFilter.SetDownstreamBarsDimensions(ship_geo.MuFilter.DownstreamBarX, ship_geo.MuFilter.DownstreamBarY, ship_geo.MuFilter.DownstreamBarZ)
+ MuFilter.SetOverlapDownstreamBars(ship_geo.MuFilter.OverlapDownstreamBars)
+ MuFilter.SetNDownstreamBars(ship_geo.MuFilter.NDownstreamBars)
+
  MuFilter.SetCenterZ(ship_geo.MuFilter.Zcenter)
  MuFilter.SetXYDisplacement(ship_geo.MuFilter.ShiftX, ship_geo.MuFilter.ShiftY)
  MuFilter.SetYPlanesDisplacement(ship_geo.MuFilter.ShiftDY)

--- a/python/shipLHC_conf.py
+++ b/python/shipLHC_conf.py
@@ -66,6 +66,7 @@ def configure(run,ship_geo,Gfield=''):
  MuFilter.SetDownstreamPlanesDimensions(ship_geo.MuFilter.DownstreamDetX, ship_geo.MuFilter.DownstreamDetY, ship_geo.MuFilter.DownstreamDetZ)
  MuFilter.SetNDownstreamPlanes(ship_geo.MuFilter.NDownstreamPlanes)
  MuFilter.SetDownstreamBarsDimensions(ship_geo.MuFilter.DownstreamBarX, ship_geo.MuFilter.DownstreamBarY, ship_geo.MuFilter.DownstreamBarZ)
+ MuFilter.SetDownstreamVerticalBarsDimensions(ship_geo.MuFilter.DownstreamBarX_ver, ship_geo.MuFilter.DownstreamBarY_ver, ship_geo.MuFilter.DownstreamBarZ_ver)
  MuFilter.SetOverlapDownstreamBars(ship_geo.MuFilter.OverlapDownstreamBars)
  MuFilter.SetNDownstreamBars(ship_geo.MuFilter.NDownstreamBars)
 

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -273,7 +273,7 @@ void MuFilter::ConstructGeometry()
 
 	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar);
 	  
-	  volUpstreamDet->AddNode(volMuUpstreamBar,ibar,yztrans);
+	  volUpstreamDet->AddNode(volMuUpstreamBar,ibar+1E+3,yztrans);
 			   }
 	//*************************************DOWNSTREAM (high granularity) SECTION*****************//
 	//Downstream Detector planes definition
@@ -293,7 +293,7 @@ void MuFilter::ConstructGeometry()
 	//adding staggered bars, second part, 77 bars, each for x and y coordinates
 	
 	TGeoBBox *MuDownstreamBar_hor = new TGeoBBox("MuDownstreamBar_hor",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2);
-	TGeoVolume *volMuDownstreamBar_hor = new TGeoVolume("volMuDownstreamStaggeredBar_hor",MuDownstreamBar_hor,Scint);
+	TGeoVolume *volMuDownstreamBar_hor = new TGeoVolume("volMuDownstreamBar_hor",MuDownstreamBar_hor,Scint);
 	volMuDownstreamBar_hor->SetLineColor(kBlue+2);
 	AddSensitiveVolume(volMuDownstreamBar_hor);
 
@@ -313,7 +313,7 @@ void MuFilter::ConstructGeometry()
 
 	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar_hor);
 	  
-	  volDownstreamDet->AddNode(volMuDownstreamBar_hor,ibar,yztrans);
+	  volDownstreamDet->AddNode(volMuDownstreamBar_hor,ibar+1E+3,yztrans);
 	  //adding vertical bars for x
 
 	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarX_ver/2. + (fDownstreamBarX_ver - fDownstreamBarOverlap)*ibar; 
@@ -321,7 +321,7 @@ void MuFilter::ConstructGeometry()
 
 	  TGeoTranslation *xztrans = new TGeoTranslation(dx_bar,0,dz_bar_ver);
 	  
-	  volDownstreamDet->AddNode(volMuDownstreamBar_ver,ibar+1E+3,xztrans);  
+	  volDownstreamDet->AddNode(volMuDownstreamBar_ver,ibar+1E+5,xztrans);  
        
 			   }    
 }

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -94,13 +94,6 @@ void MuFilter::SetIronBlockDimensions(Double_t x, Double_t y, Double_t z)
 	fFeBlockZ = z;
 }
 
-void MuFilter::SetTimingPlanesDimensions(Double_t x, Double_t y, Double_t z)
-{
-	fTDetX = x;
-	fTDetY = y;
-	fTDetZ = z;
-}
-
 void MuFilter::SetMuFilterDimensions(Double_t x, Double_t y, Double_t z)
 {	
 	fMuFilterX = x;
@@ -108,9 +101,62 @@ void MuFilter::SetMuFilterDimensions(Double_t x, Double_t y, Double_t z)
 	fMuFilterZ = z;
 }
 
-void MuFilter::SetNplanes(Int_t n)
+void MuFilter::SetUpstreamPlanesDimensions(Double_t x, Double_t y, Double_t z)
 {
-	fNplanes = n;
+	fUpstreamDetX = x;
+	fUpstreamDetY = y;
+	fUpstreamDetZ = z;
+}
+
+void MuFilter::SetNUpstreamPlanes(Int_t n)
+{
+	fNUpstreamPlanes = n;
+}
+
+void MuFilter::SetUpstreamBarsDimensions(Double_t x, Double_t y, Double_t z)
+{
+        fUpstreamBarX = x;
+	fUpstreamBarY = y;
+	fUpstreamBarZ = z;
+}
+
+void MuFilter::SetOverlapUpstreamBars(Double_t overlap)
+{
+  	fUpstreamBarOverlap = overlap;
+}
+
+void MuFilter::SetNUpstreamBars(Int_t n)
+{
+	fNUpstreamBars = n;
+}
+
+void MuFilter::SetDownstreamPlanesDimensions(Double_t x, Double_t y, Double_t z)
+{
+	fDownstreamDetX = x;
+	fDownstreamDetY = y;
+	fDownstreamDetZ = z;
+}
+
+void MuFilter::SetNDownstreamPlanes(Int_t n)
+{
+	fNDownstreamPlanes = n;
+}
+
+void MuFilter::SetDownstreamBarsDimensions(Double_t x, Double_t y, Double_t z)
+{
+        fDownstreamBarX = x;
+	fDownstreamBarY = y;
+	fDownstreamBarZ = z;
+}
+
+void MuFilter::SetOverlapDownstreamBars(Double_t overlap)
+{
+  	fDownstreamBarOverlap = overlap;
+}
+
+void MuFilter::SetNDownstreamBars(Int_t n)
+{
+	fNDownstreamBars = n;
 }
 
 void MuFilter::SetCenterZ(Double_t z)
@@ -180,30 +226,82 @@ void MuFilter::ConstructGeometry()
 	TGeoVolume *volFeBlock = new TGeoVolume("volFeBlock",FeBlockBox,Fe);
 	volFeBlock->SetLineColor(19);
 
-	//Timing Detector planes definition
-	TGeoBBox *TDetBox = new TGeoBBox("TDetBox",fTDetX/2,fTDetY/2,fTDetZ/2);
-	TGeoVolume *volTDet = new TGeoVolume("volTDet",TDetBox,Scint);
-	volTDet->SetLineColor(kRed+2);
-	AddSensitiveVolume(volTDet);
-
-	top->AddNode(volMuFilter,1,new TGeoTranslation(fShiftX,fShiftY+fMuFilterY/2,fCenterZ));
-	cout<<fShiftX<<"  "<<fShiftY+fMuFilterY/2<<" "<<fCenterZ<<endl;
+	top->AddNode(volMuFilter,1,new TGeoTranslation(fShiftX,fShiftY+fMuFilterY/2,fCenterZ));       
 
 	Double_t dy = 0;
-	for(Int_t l=0; l<fNplanes; l++)
+	Double_t dz = 0;
+	
+	//*****************************************UPSTREAM SECTION*********************************//
+	//Upstream Detector planes definition
+	TGeoBBox *UpstreamDetBox = new TGeoBBox("UpstreamDetBox",fUpstreamDetX/2,fUpstreamDetY/2,fUpstreamDetZ/2);
+	TGeoVolume *volUpstreamDet = new TGeoVolume("volUpstreamDet",UpstreamDetBox,air);
+	volUpstreamDet->SetLineColor(kRed+2);
+
+	//first loop, adding detector main boxes
+	
+	for(Int_t l=0; l<fNUpstreamPlanes; l++)
 	{
-		if(l==0)
-		{
-			volMuFilter->AddNode(volFeBlock,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2,-fMuFilterZ/2+fFeBlockZ/2+l*(fFeBlockZ+fTDetZ)));
-			volMuFilter->AddNode(volTDet,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2,-fMuFilterZ/2+fFeBlockZ+fTDetZ/2+l*(fFeBlockZ+fTDetZ)));
-		}
+		if(l==1||l==4)
+			dy+=fShiftDY;
+		if(l==2||l==3)
+			dy+= fShiftDY/2;       
+		volMuFilter->AddNode(volFeBlock,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+dz));
+		volMuFilter->AddNode(volUpstreamDet,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fUpstreamDetZ/2+dz));
+		dz+=fFeBlockZ+fUpstreamDetZ;
+	}
+
+	//adding staggered bars, first part, only 11 bars, (single stations, readout on both ends)
+	
+	TGeoBBox *MuUpstreamBar = new TGeoBBox("MuUpstreamBar",fUpstreamBarX/2, fUpstreamBarY/2, fUpstreamBarZ/2);
+	TGeoVolume *volMuUpstreamBar = new TGeoVolume("volMuUpstreamBar",MuUpstreamBar,Scint);
+	volMuUpstreamBar->SetLineColor(kBlue+2);
+	AddSensitiveVolume(volMuUpstreamBar);
+
+       //second loop, adding bars within each detector box
+	
+	for (Int_t ibar = 0; ibar < fNUpstreamBars; ibar++){
+	  
+	  Double_t dy_bar = -fUpstreamDetY/2 + fUpstreamBarY/2. + (fUpstreamBarY - fUpstreamBarOverlap)*ibar; 
+	  Double_t dz_bar = fUpstreamDetZ/2 * (ibar%2 - 1./2.); //on the left or right side of the volume 
+	  
+	  volUpstreamDet->AddNode(volMuUpstreamBar,ibar,new TGeoTranslation(0,dy_bar,dz_bar));
+			   }
+	//*************************************DOWNSTREAM (high granularity) SECTION*****************//
+	//Downstream Detector planes definition
+	TGeoBBox *DownstreamDetBox = new TGeoBBox("DownstreamDetBox",fDownstreamDetX/2,fDownstreamDetY/2,fDownstreamDetZ/2);
+	TGeoVolume *volDownstreamDet = new TGeoVolume("volDownstreamDet",DownstreamDetBox,air);
+	volDownstreamDet->SetLineColor(kRed+2);
+
+        //first loop, adding detector main boxes
+
+	for(Int_t l=0; l<fNDownstreamPlanes; l++)
+	{
 		if(l==1||l==4)
 			dy+=fShiftDY;
 		if(l==2||l==3)
 			dy+= fShiftDY/2;
-		volMuFilter->AddNode(volFeBlock,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+l*(fFeBlockZ+fTDetZ)));
-		volMuFilter->AddNode(volTDet,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fTDetZ/2+l*(fFeBlockZ+fTDetZ)));
+		
+		volMuFilter->AddNode(volFeBlock,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+dz));
+		volMuFilter->AddNode(volDownstreamDet,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fDownstreamDetZ/2+dz));
+		dz+=fFeBlockZ+fUpstreamDetZ;
 	}
+
+	//adding staggered bars, second part, 77 bars, each for x and y coordinates
+	
+	TGeoBBox *MuDownstreamBar = new TGeoBBox("MuDownstreamBar",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2);
+	TGeoVolume *volMuDownstreamBar = new TGeoVolume("volMuDownstreamBar",MuDownstreamBar,Scint);
+	volMuDownstreamBar->SetLineColor(kBlue+2);
+	AddSensitiveVolume(volMuDownstreamBar);
+
+	//second loop, adding bars within each detector box
+	
+	for (Int_t ibar = 0; ibar < fNDownstreamBars; ibar++){
+	  
+	  Double_t dy_bar = -fDownstreamDetY/2 + fDownstreamBarY/2. + (fDownstreamBarY - fDownstreamBarOverlap)*ibar; 
+	  Double_t dz_bar = fDownstreamDetZ/2 * (ibar%2 - 1./2.); //on the left or right side of the volume 
+	  
+	  volDownstreamDet->AddNode(volMuDownstreamBar,ibar,new TGeoTranslation(0,dy_bar,dz_bar));
+			   }    
 }
 
 Bool_t  MuFilter::ProcessHits(FairVolume* vol)

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -43,7 +43,6 @@
 #include "ShipUnit.h"
 #include "ShipStack.h"
 
-#include "TGeoCompositeShape.h"
 #include "TGeoUniformMagField.h"
 #include <stddef.h>                     // for NULL
 #include <iostream>                     // for operator<<, basic_ostream,etc
@@ -303,7 +302,7 @@ void MuFilter::ConstructGeometry()
 	volMuDownstreamBar_hor->SetLineColor(kBlue+2);
 	AddSensitiveVolume(volMuDownstreamBar_hor);
 
-  //vertical bars, for x measurement
+	//vertical bars, for x measurement
 	TGeoBBox *MuDownstreamBar_ver = new TGeoBBox("MuDownstreamBar_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2, fDownstreamBarZ/2);
 	TGeoVolume *volMuDownstreamBar_ver = new TGeoVolume("volMuDownstreamBar_ver",MuDownstreamBar_ver,Scint);
 	volMuDownstreamBar_ver->SetLineColor(kGreen+2);
@@ -320,7 +319,7 @@ void MuFilter::ConstructGeometry()
 	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar_hor);
 	  
 	  volDownstreamDet->AddNode(volMuDownstreamBar_hor,ibar,yztrans);
-    //adding vertical bars for x
+	  //adding vertical bars for x
 
 	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarX_ver/2. + (fDownstreamBarX_ver - fDownstreamBarOverlap)*ibar; 
           Double_t dz_bar_ver = -fDownstreamDetZ/2. + 2*fDownstreamBarZ + fDownstreamBarZ/2. * (2 *(ibar%2) + 1.); //after the two staggered horizontal ones	  

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -260,37 +260,21 @@ void MuFilter::ConstructGeometry()
 
 	//adding staggered bars, first part, only 11 bars, (single stations, readout on both ends)
 	
-	TGeoBBox *MuUpstreamBar = new TGeoBBox("MuUpstreamBar",fUpstreamBarX/2, fUpstreamBarY/2, fUpstreamBarZ/2 * 2.);
-
-	TGeoBBox *Rect = new TGeoBBox("Rect",fUpstreamBarX/2, fUpstreamBarOverlap/2., fUpstreamBarZ/2); //to be cutted away
-	TGeoTranslation *uppercut = new TGeoTranslation(0,fUpstreamBarY/2. - fUpstreamBarOverlap/2., fUpstreamBarZ/2.);
-	TGeoTranslation *lowercut = new TGeoTranslation(0,-fUpstreamBarY/2. + fUpstreamBarOverlap/2., fUpstreamBarZ/2.);
-	//registering transformations before applying them
-	uppercut->SetName("uppercut");
-	uppercut->RegisterYourself();
-	lowercut->SetName("lowercut");
-	lowercut->RegisterYourself();
-
-	TGeoCompositeShape *MuUpstreamStaggeredBar = new TGeoCompositeShape("MuUpstreamStaggeredBar","MuUpstreamBar - (Rect:uppercut) - (Rect:lowercut)");
-	TGeoVolume *volMuUpstreamStaggeredBar = new TGeoVolume("volMuUpstreamStaggeredBar",MuUpstreamStaggeredBar,Scint);
-	volMuUpstreamStaggeredBar->SetLineColor(kBlue+2);
-	AddSensitiveVolume(volMuUpstreamStaggeredBar);
-
-        TGeoRotation *yflip = new TGeoRotation("yflip",0,0,0);
-	yflip->RotateY(180);
+	TGeoBBox *MuUpstreamBar = new TGeoBBox("MuUpstreamBar",fUpstreamBarX/2, fUpstreamBarY/2, fUpstreamBarZ/2);
+	TGeoVolume *volMuUpstreamBar = new TGeoVolume("volMuUpstreamBar",MuUpstreamBar,Scint);
+	volMuUpstreamBar->SetLineColor(kBlue+2);
+	AddSensitiveVolume(volMuUpstreamBar);
             
        //second loop, adding bars within each detector box
 	
 	for (Int_t ibar = 0; ibar < fNUpstreamBars; ibar++){
 	  
 	  Double_t dy_bar = -fUpstreamDetY/2 + fUpstreamBarY/2. + (fUpstreamBarY - fUpstreamBarOverlap)*ibar; 
-	  Double_t dz_bar = 0.; //on the left or right side of the volume
+	  Double_t dz_bar = -fUpstreamDetZ/2. + fUpstreamBarZ/2. * (2 *(ibar%2) + 1.); //on the left or right side of the volume
 
 	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar);
-	  TGeoCombiTrans *yztrans_flipped = new TGeoCombiTrans(*yztrans, *yflip);
 	  
-	  if (ibar%2==0) volUpstreamDet->AddNode(volMuUpstreamStaggeredBar,ibar,yztrans);
-	  else volUpstreamDet->AddNode(volMuUpstreamStaggeredBar,ibar,yztrans_flipped);
+	  volUpstreamDet->AddNode(volMuUpstreamBar,ibar,yztrans);
 			   }
 	//*************************************DOWNSTREAM (high granularity) SECTION*****************//
 	//Downstream Detector planes definition
@@ -314,41 +298,16 @@ void MuFilter::ConstructGeometry()
 
 	//adding staggered bars, second part, 77 bars, each for x and y coordinates
 	
-	TGeoBBox *MuDownstreamBar_hor = new TGeoBBox("MuDownstreamBar_hor",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2 *2);
-       
-	TGeoBBox *Rectdownstream_hor = new TGeoBBox("Rectdownstream_hor",fDownstreamBarX/2, fDownstreamBarOverlap/2., fDownstreamBarZ/2); //to be cutted away
-	TGeoTranslation *uppercutdownstream_hor = new TGeoTranslation(0,fDownstreamBarY/2. - fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
-	TGeoTranslation *lowercutdownstream_hor = new TGeoTranslation(0,-fDownstreamBarY/2. + fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
-	//registering transformations before applying them
-	uppercutdownstream_hor->SetName("uppercutdownstream_hor");
-	uppercutdownstream_hor->RegisterYourself();
-	lowercutdownstream_hor->SetName("lowercutdownstream_hor");
-	lowercutdownstream_hor->RegisterYourself();
+	TGeoBBox *MuDownstreamBar_hor = new TGeoBBox("MuDownstreamBar_hor",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2);
+	TGeoVolume *volMuDownstreamBar_hor = new TGeoVolume("volMuDownstreamStaggeredBar_hor",MuDownstreamBar_hor,Scint);
+	volMuDownstreamBar_hor->SetLineColor(kBlue+2);
+	AddSensitiveVolume(volMuDownstreamBar_hor);
 
-	TGeoCompositeShape *MuDownstreamStaggeredBar_hor = new TGeoCompositeShape("MuDownstreamStaggeredBar_hor","MuDownstreamBar_hor - (Rectdownstream_hor:uppercutdownstream_hor) - (Rectdownstream_hor:lowercutdownstream_hor)");
-	TGeoVolume *volMuDownstreamStaggeredBar_hor = new TGeoVolume("volMuDownstreamStaggeredBar_hor",MuDownstreamStaggeredBar_hor,Scint);
-	volMuDownstreamStaggeredBar_hor->SetLineColor(kBlue+2);
-	AddSensitiveVolume(volMuDownstreamStaggeredBar_hor);
-
-        TGeoRotation *xflip = new TGeoRotation("xflip",0,0,0);
-	xflip->RotateX(180);
-
-        //vertical bars, for x measurement
-	TGeoBBox *MuDownstreamBar_ver = new TGeoBBox("MuDownstreamBar_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2, fDownstreamBarZ/2 *2);
-       
-	TGeoBBox *Rectdownstream_ver = new TGeoBBox("Rectdownstream_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2., fDownstreamBarZ/2); //to be cutted away
-	TGeoTranslation *uppercutdownstream_ver = new TGeoTranslation(fDownstreamBarX_ver/2. - fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
-	TGeoTranslation *lowercutdownstream_ver = new TGeoTranslation(-fDownstreamBarX_ver/2. + fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
-	//registering transformations before applying them
-	uppercutdownstream_ver->SetName("uppercutdownstream_ver");
-	uppercutdownstream_ver->RegisterYourself();
-	lowercutdownstream_ver->SetName("lowercutdownstream_ver");
-	lowercutdownstream_ver->RegisterYourself();
-
-	TGeoCompositeShape *MuDownstreamStaggeredBar_ver = new TGeoCompositeShape("MuDownstreamStaggeredBar_ver","MuDownstreamBar_ver - (Rectdownstream_ver:uppercutdownstream_ver) - (Rectdownstream_ver:lowercutdownstream_ver)");
-	TGeoVolume *volMuDownstreamStaggeredBar_ver = new TGeoVolume("volMuDownstreamStaggeredBar_ver",MuDownstreamStaggeredBar_ver,Scint);
-	volMuDownstreamStaggeredBar_ver->SetLineColor(kGreen+2);
-	AddSensitiveVolume(volMuDownstreamStaggeredBar_ver);
+  //vertical bars, for x measurement
+	TGeoBBox *MuDownstreamBar_ver = new TGeoBBox("MuDownstreamBar_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2, fDownstreamBarZ/2);
+	TGeoVolume *volMuDownstreamBar_ver = new TGeoVolume("volMuDownstreamBar_ver",MuDownstreamBar_ver,Scint);
+	volMuDownstreamBar_ver->SetLineColor(kGreen+2);
+	AddSensitiveVolume(volMuDownstreamBar_ver);
 
 	//second loop, adding bars within each detector box
 	
@@ -356,23 +315,19 @@ void MuFilter::ConstructGeometry()
 	  //adding verizontal bars for y
 
 	  Double_t dy_bar = -fDownstreamDetY/2 + fDownstreamBarY/2. + (fDownstreamBarY - fDownstreamBarOverlap)*ibar; 
-	  Double_t dz_bar_hor = -fDownstreamDetZ/2 + (fDownstreamBarZ/2*2); //on the left or right side of the volume
+          Double_t dz_bar_hor = -fDownstreamDetZ/2. + fDownstreamBarZ/2. * (2 *(ibar%2) + 1.); //on the left or right side of the volume
 
 	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar_hor);
-	  TGeoCombiTrans *yztrans_flipped = new TGeoCombiTrans(*yztrans, *yflip);
 	  
-	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,yztrans);
-	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,yztrans_flipped);
-          //adding vertical bars for x
+	  volDownstreamDet->AddNode(volMuDownstreamBar_hor,ibar,yztrans);
+    //adding vertical bars for x
 
 	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarX_ver/2. + (fDownstreamBarX_ver - fDownstreamBarOverlap)*ibar; 
-	  Double_t dz_bar_ver = +fDownstreamDetZ/2 - (fDownstreamBarZ/2*2); //on the left or right side of the volume
+          Double_t dz_bar_ver = -fDownstreamDetZ/2. + 2*fDownstreamBarZ + fDownstreamBarZ/2. * (2 *(ibar%2) + 1.); //after the two staggered horizontal ones	  
 
 	  TGeoTranslation *xztrans = new TGeoTranslation(dx_bar,0,dz_bar_ver);
-	  TGeoCombiTrans *xztrans_flipped = new TGeoCombiTrans(*xztrans, *xflip);
 	  
-	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_ver,ibar+1E+3,xztrans);
-	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_ver,ibar+1E+3,xztrans_flipped);	 	  
+	  volDownstreamDet->AddNode(volMuDownstreamBar_ver,ibar+1E+3,xztrans);  
        
 			   }    
 }

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -150,6 +150,13 @@ void MuFilter::SetDownstreamBarsDimensions(Double_t x, Double_t y, Double_t z)
 	fDownstreamBarZ = z;
 }
 
+void MuFilter::SetDownstreamVerticalBarsDimensions(Double_t x, Double_t y, Double_t z)
+{
+        fDownstreamBarX_ver = x;
+	fDownstreamBarY_ver = y;
+	fDownstreamBarZ_ver = z;
+}
+
 void MuFilter::SetOverlapDownstreamBars(Double_t overlap)
 {
   	fDownstreamBarOverlap = overlap;
@@ -300,38 +307,18 @@ void MuFilter::ConstructGeometry()
 		if(l==2||l==3)
 			dy+= fShiftDY/2;
 		
-		volMuFilter->AddNode(volFeBlock,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+dz));
-		volMuFilter->AddNode(volDownstreamDet,l,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fDownstreamDetZ/2+dz));
+		volMuFilter->AddNode(volFeBlock,l+fNUpstreamPlanes,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+dz));
+		volMuFilter->AddNode(volDownstreamDet,l+fNUpstreamPlanes,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fDownstreamDetZ/2+dz));
 		dz+=fFeBlockZ+fDownstreamDetZ;
 	}
 
 	//adding staggered bars, second part, 77 bars, each for x and y coordinates
 	
-	TGeoBBox *MuDownstreamBar = new TGeoBBox("MuDownstreamBar",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2 *2);
+	TGeoBBox *MuDownstreamBar_hor = new TGeoBBox("MuDownstreamBar_hor",fDownstreamBarX/2, fDownstreamBarY/2, fDownstreamBarZ/2 *2);
        
-	TGeoBBox *Rectdownstream = new TGeoBBox("Rectdownstream",fDownstreamBarX/2, fDownstreamBarOverlap/2., fDownstreamBarZ/2); //to be cutted away
-	TGeoTranslation *uppercutdownstream = new TGeoTranslation(0,fDownstreamBarY/2. - fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
-	TGeoTranslation *lowercutdownstream = new TGeoTranslation(0,-fDownstreamBarY/2. + fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
-	//registering transformations before applying them
-	uppercutdownstream->SetName("uppercutdownstream");
-	uppercutdownstream->RegisterYourself();
-	lowercutdownstream->SetName("lowercutdownstream");
-	lowercutdownstream->RegisterYourself();
-
-	TGeoCompositeShape *MuDownstreamStaggeredBar = new TGeoCompositeShape("MuDownstreamStaggeredBar","MuDownstreamBar - (Rectdownstream:uppercutdownstream) - (Rectdownstream:lowercutdownstream)");
-	TGeoVolume *volMuDownstreamStaggeredBar = new TGeoVolume("volMuDownstreamStaggeredBar",MuDownstreamStaggeredBar,Scint);
-	volMuDownstreamStaggeredBar->SetLineColor(kBlue+2);
-	AddSensitiveVolume(volMuDownstreamStaggeredBar);
-
-        TGeoRotation *xflip = new TGeoRotation("xflip",0,0,0);
-	xflip->RotateX(180);
-
-        //horizontal section, same but inverted sizes
-	TGeoBBox *MuDownstreamBar_hor = new TGeoBBox("MuDownstreamBar_hor",fDownstreamBarY/2, fFeBlockY/2, fDownstreamBarZ/2 *2);
-       
-	TGeoBBox *Rectdownstream_hor = new TGeoBBox("Rectdownstream_hor",fDownstreamBarY/2, fFeBlockY/2., fDownstreamBarZ/2); //to be cutted away
-	TGeoTranslation *uppercutdownstream_hor = new TGeoTranslation(fDownstreamBarY/2. - fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
-	TGeoTranslation *lowercutdownstream_hor = new TGeoTranslation(-fDownstreamBarY/2. + fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
+	TGeoBBox *Rectdownstream_hor = new TGeoBBox("Rectdownstream_hor",fDownstreamBarX/2, fDownstreamBarOverlap/2., fDownstreamBarZ/2); //to be cutted away
+	TGeoTranslation *uppercutdownstream_hor = new TGeoTranslation(0,fDownstreamBarY/2. - fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
+	TGeoTranslation *lowercutdownstream_hor = new TGeoTranslation(0,-fDownstreamBarY/2. + fDownstreamBarOverlap/2., fDownstreamBarZ/2.);
 	//registering transformations before applying them
 	uppercutdownstream_hor->SetName("uppercutdownstream_hor");
 	uppercutdownstream_hor->RegisterYourself();
@@ -340,32 +327,52 @@ void MuFilter::ConstructGeometry()
 
 	TGeoCompositeShape *MuDownstreamStaggeredBar_hor = new TGeoCompositeShape("MuDownstreamStaggeredBar_hor","MuDownstreamBar_hor - (Rectdownstream_hor:uppercutdownstream_hor) - (Rectdownstream_hor:lowercutdownstream_hor)");
 	TGeoVolume *volMuDownstreamStaggeredBar_hor = new TGeoVolume("volMuDownstreamStaggeredBar_hor",MuDownstreamStaggeredBar_hor,Scint);
-	volMuDownstreamStaggeredBar_hor->SetLineColor(kGreen+2);
+	volMuDownstreamStaggeredBar_hor->SetLineColor(kBlue+2);
 	AddSensitiveVolume(volMuDownstreamStaggeredBar_hor);
+
+        TGeoRotation *xflip = new TGeoRotation("xflip",0,0,0);
+	xflip->RotateX(180);
+
+        //vertical bars, for x measurement
+	TGeoBBox *MuDownstreamBar_ver = new TGeoBBox("MuDownstreamBar_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2, fDownstreamBarZ/2 *2);
+       
+	TGeoBBox *Rectdownstream_ver = new TGeoBBox("Rectdownstream_ver",fDownstreamBarX_ver/2, fDownstreamBarY_ver/2., fDownstreamBarZ/2); //to be cutted away
+	TGeoTranslation *uppercutdownstream_ver = new TGeoTranslation(fDownstreamBarX_ver/2. - fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
+	TGeoTranslation *lowercutdownstream_ver = new TGeoTranslation(-fDownstreamBarX_ver/2. + fDownstreamBarOverlap/2.,0, fDownstreamBarZ/2.);
+	//registering transformations before applying them
+	uppercutdownstream_ver->SetName("uppercutdownstream_ver");
+	uppercutdownstream_ver->RegisterYourself();
+	lowercutdownstream_ver->SetName("lowercutdownstream_ver");
+	lowercutdownstream_ver->RegisterYourself();
+
+	TGeoCompositeShape *MuDownstreamStaggeredBar_ver = new TGeoCompositeShape("MuDownstreamStaggeredBar_ver","MuDownstreamBar_ver - (Rectdownstream_ver:uppercutdownstream_ver) - (Rectdownstream_ver:lowercutdownstream_ver)");
+	TGeoVolume *volMuDownstreamStaggeredBar_ver = new TGeoVolume("volMuDownstreamStaggeredBar_ver",MuDownstreamStaggeredBar_ver,Scint);
+	volMuDownstreamStaggeredBar_ver->SetLineColor(kGreen+2);
+	AddSensitiveVolume(volMuDownstreamStaggeredBar_ver);
 
 	//second loop, adding bars within each detector box
 	
 	for (Int_t ibar = 0; ibar < fNDownstreamBars; ibar++){
-	  //adding horizontal bars for y
+	  //adding verizontal bars for y
 
 	  Double_t dy_bar = -fDownstreamDetY/2 + fDownstreamBarY/2. + (fDownstreamBarY - fDownstreamBarOverlap)*ibar; 
-	  Double_t dz_bar = -fDownstreamDetZ/2 + (fDownstreamBarZ/2*2); //on the left or right side of the volume
+	  Double_t dz_bar_hor = -fDownstreamDetZ/2 + (fDownstreamBarZ/2*2); //on the left or right side of the volume
 
-	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar);
+	  TGeoTranslation *yztrans = new TGeoTranslation(0,dy_bar,dz_bar_hor);
 	  TGeoCombiTrans *yztrans_flipped = new TGeoCombiTrans(*yztrans, *yflip);
 	  
-	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar,ibar,yztrans);
-	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar,ibar,yztrans_flipped);
+	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,yztrans);
+	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,yztrans_flipped);
           //adding vertical bars for x
 
-	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarY/2. + (fDownstreamBarY - fDownstreamBarOverlap)*ibar; 
-	  Double_t dz_bar_hor = +fDownstreamDetZ/2 - (fDownstreamBarZ/2*2); //on the left or right side of the volume
+	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarX_ver/2. + (fDownstreamBarX_ver - fDownstreamBarOverlap)*ibar; 
+	  Double_t dz_bar_ver = +fDownstreamDetZ/2 - (fDownstreamBarZ/2*2); //on the left or right side of the volume
 
-	  TGeoTranslation *xztrans = new TGeoTranslation(dx_bar,0,dz_bar_hor);
+	  TGeoTranslation *xztrans = new TGeoTranslation(dx_bar,0,dz_bar_ver);
 	  TGeoCombiTrans *xztrans_flipped = new TGeoCombiTrans(*xztrans, *xflip);
 	  
-	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,xztrans);
-	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_hor,ibar,xztrans_flipped);	 	  
+	  if (ibar%2==0) volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_ver,ibar+1E+3,xztrans);
+	  else volDownstreamDet->AddNode(volMuDownstreamStaggeredBar_ver,ibar+1E+3,xztrans_flipped);	 	  
        
 			   }    
 }

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -285,11 +285,6 @@ void MuFilter::ConstructGeometry()
 
 	for(Int_t l=0; l<fNDownstreamPlanes; l++)
 	{
-		if(l==1||l==4)
-			dy+=fShiftDY;
-		if(l==2||l==3)
-			dy+= fShiftDY/2;
-		
 		volMuFilter->AddNode(volFeBlock,l+fNUpstreamPlanes,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ/2+dz));
 		volMuFilter->AddNode(volDownstreamDet,l+fNUpstreamPlanes,new TGeoTranslation(0,fMuFilterY/2-fFeBlockY/2-dy,-fMuFilterZ/2+fFeBlockZ+fDownstreamDetZ/2+dz));
 		dz+=fFeBlockZ+fDownstreamDetZ;

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -31,13 +31,25 @@ class MuFilter : public FairDetector
 		void ConstructGeometry();
 
 		/** Other functions **/
-		void SetIronBlockDimensions(Double_t , Double_t, Double_t);
-		void SetTimingPlanesDimensions(Double_t, Double_t, Double_t);
+		void SetIronBlockDimensions(Double_t , Double_t, Double_t);	       
 		void SetMuFilterDimensions(Double_t, Double_t, Double_t);
-		void SetNplanes(Int_t);
 		void SetCenterZ(Double_t);
 		void SetXYDisplacement(Double_t , Double_t );
 		void SetYPlanesDisplacement(Double_t);
+
+		void SetUpstreamPlanesDimensions(Double_t, Double_t, Double_t);
+		void SetNUpstreamPlanes(Int_t);
+		void SetUpstreamBarsDimensions(Double_t, Double_t, Double_t);
+		void SetNUpstreamBars(Int_t);
+		void SetOverlapUpstreamBars(Double_t);
+
+		void SetDownstreamPlanesDimensions(Double_t, Double_t, Double_t);
+		void SetNDownstreamPlanes(Int_t);
+		void SetDownstreamBarsDimensions(Double_t, Double_t, Double_t);
+		void SetNDownstreamBars(Int_t);
+		void SetOverlapDownstreamBars(Double_t);
+
+		
 
 
 		/**      Initialization of the detector is done here    */
@@ -74,7 +86,7 @@ class MuFilter : public FairDetector
 		MuFilter(const MuFilter&);
 		MuFilter& operator=(const MuFilter&);
 
-		ClassDef(MuFilter,1)
+		ClassDef(MuFilter,2)
 
 	private:
 
@@ -99,16 +111,36 @@ class MuFilter : public FairDetector
 			Double_t fFeBlockY;     //|
 			Double_t fFeBlockZ;     //|
 
-			Double_t fTDetX;	//|Timing detector planes dimensions
-			Double_t fTDetY;	//|
-			Double_t fTDetZ;	//|
+			Double_t fUpstreamDetX;	//|Upstream muon detector planes dimensions
+			Double_t fUpstreamDetY;	//|
+			Double_t fUpstreamDetZ;	//|
+			Double_t fUpstreamBarOverlap; //|Size of overlap (staggering)
 
-			Double_t fCenterZ;	//Zposition of the muon filter
+			Int_t fNUpstreamPlanes;	//|Number of planes
+
+			Double_t fUpstreamBarX; //|Staggered bars of upstream section
+			Double_t fUpstreamBarY;
+			Double_t fUpstreamBarZ;
+
+		        Int_t fNUpstreamBars;   //|Number of staggered bars
+
+			Double_t fDownstreamDetX;	//|Downstream muon detector planes dimensions
+			Double_t fDownstreamDetY;	//|
+			Double_t fDownstreamDetZ;	//|
+
+			Int_t fNDownstreamPlanes;	//|Number of planes
+
+			Double_t fDownstreamBarX; //|Staggered bars of upstream section
+			Double_t fDownstreamBarY;
+			Double_t fDownstreamBarZ;
+			Double_t fDownstreamBarOverlap; //|Size of overlap (staggering)
+
+		        Int_t fNDownstreamBars;   //|Number of staggered bars
+
+			Double_t fCenterZ;	//|Zposition of the muon filter
 			Double_t fShiftX;	//|Shift in x-y wrt beam line
 			Double_t fShiftY;	//|
-			Double_t fShiftDY;	//Shift in DY of the first 6 planes (2 cm)
-
-			Int_t fNplanes;		//Number of planes
+			Double_t fShiftDY;	//|Shift in DY of the first 6 planes (2 cm)
 
 			Int_t InitMedium(const char* name);
 };

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -46,6 +46,7 @@ class MuFilter : public FairDetector
 		void SetDownstreamPlanesDimensions(Double_t, Double_t, Double_t);
 		void SetNDownstreamPlanes(Int_t);
 		void SetDownstreamBarsDimensions(Double_t, Double_t, Double_t);
+                void SetDownstreamVerticalBarsDimensions(Double_t, Double_t, Double_t);
 		void SetNDownstreamBars(Int_t);
 		void SetOverlapDownstreamBars(Double_t);
 
@@ -136,6 +137,10 @@ class MuFilter : public FairDetector
 			Double_t fDownstreamBarOverlap; //|Size of overlap (staggering)
 
 		        Int_t fNDownstreamBars;   //|Number of staggered bars
+
+  			Double_t fDownstreamBarX_ver; //|Staggered bars of upstream section, vertical bars for x measurement
+			Double_t fDownstreamBarY_ver;
+			Double_t fDownstreamBarZ_ver;
 
 			Double_t fCenterZ;	//|Zposition of the muon filter
 			Double_t fShiftX;	//|Shift in x-y wrt beam line


### PR DESCRIPTION
Dear Annarita,

here you can find my updates to the MuonFilter code. A brief summary of my changes:

1)The volTDet instance is replaced by two separated volUpstreamDet and volDownstreamDet, representing the two sections of the muon detector;

2)An additional level of volumes is added, representing the staggered bars. The upstream section has only 11 horizontal bars, while the downstream section has 77 horizontal and 77 vertical bars.

An important note: launching the overlap/extrusion check I have noticed that, due to the gradual shift of the muon filter volumes towards bottom, the volMuFilter_1 volume (the "mother box" volume) overlaps with "floor_1" volume. 
I have just confirmed that this issue appears also in your original version, and it is not from my changes. 
The only solution I can think for this issue would be to operate boolean subtractions on the mother box shape, "cutting away" the overlapping empty regions. Please tell me if you can propose a simpler solution. 

Here a display with MuFilter container visible, to show the overlap:

![fairship_layout_withcontainer](https://user-images.githubusercontent.com/18480751/98471307-9a054580-21eb-11eb-9c93-6162f534bfb0.png)

